### PR TITLE
fix: corrected host/port options shape in doc and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,8 @@ await fastify.register(
       database: 'DATABASE_NAME',
       username: 'DATABASE_USER_NAME',
       password: 'DATABASE_USER_PASSWORD',
-      options: {
-        host: 'DATABASE_HOST_OR_SERVER',
-        port: 'DATABASE_PORT'
-      }
+      host: 'DATABASE_HOST_OR_SERVER',
+      port: 'DATABASE_PORT'
     }
   }
 )

--- a/test.js
+++ b/test.js
@@ -18,10 +18,8 @@ test('database connection', done => {
         database: 'sequelize',
         username: 'root',
         password: 'root',
-        options: {
-          host: 'localhost',
-          port: 3306
-        }
+        host: 'localhost',
+        port: 3306
       }
     }
   )


### PR DESCRIPTION
In Sequelize v6, the options for host and port are now top level.  This PR updates both the example in Readme.md and the test to reflect this object shape.